### PR TITLE
Windows compatibility

### DIFF
--- a/CryptoHandler.py
+++ b/CryptoHandler.py
@@ -1,5 +1,9 @@
 import os
 
+# Windows compatibility
+if not hasattr(os, "fchmod"):
+	setattr(os, "fchmod", lambda x, y: None)
+
 import base64
 
 from Crypto import Random


### PR DESCRIPTION
As alternative [os.fchmod](https://github.com/spring/uberserver/blob/de1736a50c5eecd1f6ab44aa780b64e3e398c9ed/CryptoHandler.py#L189) call can be wrapped into try-except:
```python
try:
    os.fchmod(f.fileno(), 0o600)
    # Method exists, and was used.  
except AttributeError:
    # Method does not exist.  What now?
    # This approach blocks legal AttributeError exceptions
```
Or maybe create platform-dependent module, move "write_file" there and use os.fchmod for Unix and os.chmod for Windows?

**Or just use os.chmod?**
```
-	os.fchmod(f.fileno(), 0o600)
+	os.chmod(file_name, 0o600)
```