### PR TITLE
"PROMOTE <battleid>" support

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -128,7 +128,7 @@ class DataHandler:
 			self.channels[name] = newchan
 
 		self.parseFiles()
-		self.protocol = Protocol.Protocol(self) # MasterBel2 Note: Why is this defined here and not used again?
+		self.protocol = Protocol.Protocol(self) 
 		self.chanserv = ChanServ.ChanServClient(self, (self.online_ip, 0), self.session_id)
 
 		for name in channels:

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -2487,7 +2487,7 @@ class Protocol:
 		target = self.clientFromUsername(username)
 		if target:
 			if target.ip_address in self._root.trusted_proxies:
-				ip = target.local_ip
+				ip = "%s via proxy %s" % (target.local_ip, target.ip_address)
 			else:
 				ip = target.ip_address
 			self.out_SERVERMSG(client, '<%s> is currently bound to %s' % (username, ip))

--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -2484,8 +2484,13 @@ class Protocol:
 
 		@required.str username: The target user.
 		'''
-		if username in self._root.usernames:
-			self.out_SERVERMSG(client, '<%s> is currently bound to %s' % (username, self._root.usernames[username].ip_address))
+		target = self.clientFromUsername(username)
+		if target:
+			if target.ip_address in self._root.trusted_proxies:
+				ip = target.local_ip
+			else:
+				ip = target.ip_address
+			self.out_SERVERMSG(client, '<%s> is currently bound to %s' % (username, ip))
 			return
 
 		ip = self.userdb.get_ip(username)


### PR DESCRIPTION
I've added support for a command "PROMOTE <battleid>" which when recieved by the server will be distributed to all other clients. If this is used instead of promoting in channels it will allow for all host bots to be removed from #main