### PR TITLE
Fix duplicate `REQUESTBATTLESTATUS` sent to host

### DIFF
--- a/protocol/Protocol.py
+++ b/protocol/Protocol.py
@@ -1801,7 +1801,6 @@ class Protocol:
 
 		client.Send('OPENBATTLE %s' % battle.battle_id)
 		battle.joinBattle(client)
-		client.Send('REQUESTBATTLESTATUS')
 
 	def in_JOINBATTLE(self, client, battle_id, key=None, scriptPassword=None):
 		'''


### PR DESCRIPTION
Call to `battle.joinBattle()` results in `client.Send('REQUESTBATTLESTATUS')` and has no exit-paths before that call, making the call on the line directly after `battle.joinBattle()` entirely redundant.